### PR TITLE
Fix/container start

### DIFF
--- a/arcturus/Dockerfile
+++ b/arcturus/Dockerfile
@@ -48,7 +48,7 @@ FROM amazoncorretto:19
 
 WORKDIR /app
 
-RUN yum update -y && yum install -y mariadb bash && yum clean all
+RUN yum update -y && yum install -y mariadb bash nc && yum clean all
 
 COPY --from=builder-ms4 /build/arcturus-community/target/emulator.jar /app/emulator.jar
 RUN mkdir -p /app/plugins

--- a/compose.yaml
+++ b/compose.yaml
@@ -226,6 +226,8 @@ services:
       - ".cms.env:/var/www/html/.env"
       - "./atomcms/storage:/var/www/html/storage/app/public"
       - "./atomcms/logs:/var/www/html/storage/logs"
+    tty: true
+    stdin_open: true
     restart: unless-stopped
     networks: [nitro]
     healthcheck:

--- a/compose.yaml
+++ b/compose.yaml
@@ -161,7 +161,7 @@ services:
     restart: unless-stopped
     depends_on:
       - imgproxy
-      - assets-downloader
+      # - assets-downloader
       - assets-builder
     env_file:
       - .env
@@ -172,7 +172,7 @@ services:
       - ./assets/:/usr/share/nginx/html
     networks: [nitro]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost"]
+      test: ["CMD", "curl", "-f", "http://localhost/assets/README.md"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
This PR addresses issue #1 by doing the following
- Changed healthcheck test for `assets` container to get rid of ngnix `500` error caused by a request for the root URL (Requesting the `README.md` file instead of the root directory)
- Removed `assets-downloader` dependency from `assets`, as it should depend on `assets-builder`, which itself depends on `assets-downloader`.
- Added `nc` package to the `arcturus` container, to make sure the `nc` healthcheck actually works.
- Added `tty` and `stdin_open` to `cms` container to avoid the error `stty: standard input: Inappropriate ioctl for device`.

At the moment, the compose still doesn't work, due to the `cms` container failing the healthcheck test and not opening the dashboard properly.